### PR TITLE
Automate overrides via modify-babel-preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,13 @@
-module.exports = {
-  plugins: [
-    [require("babel-plugin-transform-es2015-template-literals"), {loose: true}],
-    require("babel-plugin-transform-es2015-literals"),
-    require("babel-plugin-transform-es2015-function-name"),
-    require("babel-plugin-transform-es2015-arrow-functions"),
-    require("babel-plugin-transform-es2015-block-scoped-functions"),
-    [require("babel-plugin-transform-es2015-classes"), {loose: true}],
-    require("babel-plugin-transform-es2015-object-super"),
-    require("babel-plugin-transform-es2015-shorthand-properties"),
-    [require("babel-plugin-transform-es2015-computed-properties"), {loose: true}],
-    [require("babel-plugin-transform-es2015-for-of"), {loose: true}],
-    require("babel-plugin-transform-es2015-sticky-regex"),
-    require("babel-plugin-transform-es2015-unicode-regex"),
-    require("babel-plugin-transform-es2015-constants"),
-    [require("babel-plugin-transform-es2015-spread"), {loose: true}],
-    require("babel-plugin-transform-es2015-parameters"),
-    [require("babel-plugin-transform-es2015-destructuring"), {loose: true}],
-    require("babel-plugin-transform-es2015-block-scoping"),
-    require("babel-plugin-transform-es2015-typeof-symbol"),
-    [require("babel-plugin-transform-es2015-modules-commonjs"), {loose: true}],
-    [require("babel-plugin-transform-regenerator"), {async: false, asyncGenerators: false}],
-  ]
-};
+var modify = require('modify-babel-preset');
+
+var LOOSE = {loose: true};
+
+module.exports = modify('es2015', {
+    'transform-es2015-template-literals': LOOSE,
+    'transform-es2015-classes': LOOSE,
+    'transform-es2015-computed-properties': LOOSE,
+    'transform-es2015-for-of': LOOSE,
+    'transform-es2015-spread': LOOSE,
+    'transform-es2015-destructuring': LOOSE,
+    'transform-es2015-modules-commonjs': LOOSE
+});

--- a/package.json
+++ b/package.json
@@ -2,31 +2,26 @@
   "name": "babel-preset-es2015-loose",
   "version": "6.1.4",
   "description": "Babel preset for all es2015 plugins, with loose mode enabled where available.",
-  "author": "Brandon Konkle <brandon@konkle.us>",
+  "authors": [
+    "Brandon Konkle <brandon@konkle.us>",
+    "Jason Miller <jason@developit.ca>"
+  ],
   "homepage": "https://babeljs.io/",
   "license": "MIT",
   "repository": "https://github.com/bkonkle/babel-preset-es2015-loose",
   "main": "index.js",
+  "scripts": {
+    "test": "node ./test | tap-spec"
+  },
   "dependencies": {
-    "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
-    "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
-    "babel-plugin-transform-es2015-block-scoping": "^6.3.13",
-    "babel-plugin-transform-es2015-classes": "^6.3.15",
-    "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
-    "babel-plugin-transform-es2015-constants": "^6.1.4",
-    "babel-plugin-transform-es2015-destructuring": "^6.3.15",
-    "babel-plugin-transform-es2015-for-of": "^6.3.13",
-    "babel-plugin-transform-es2015-function-name": "^6.3.21",
-    "babel-plugin-transform-es2015-literals": "^6.3.13",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.3.16",
-    "babel-plugin-transform-es2015-object-super": "^6.3.13",
-    "babel-plugin-transform-es2015-parameters": "^6.3.26",
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
-    "babel-plugin-transform-es2015-spread": "^6.3.14",
-    "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
-    "babel-plugin-transform-es2015-template-literals": "^6.3.13",
-    "babel-plugin-transform-es2015-typeof-symbol": "^6.3.13",
-    "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
-    "babel-plugin-transform-regenerator": "^6.3.26"
+    "modify-babel-preset": "^1.0.0"
+  },
+  "peerDependencies": {
+    "babel-preset-es2015": "*"
+  },
+  "devDependencies": {
+    "babel-preset-es2015": "^6.3.13",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.4.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,40 @@
+var test = require('tape'),
+	es2015 = require('babel-preset-es2015'),
+	es2015Loose = require('..');
+
+var LOOSE = { loose: true };
+
+var PREFIX = 'transform-es2015-';
+
+var SHOULD_BE_LOOSE = [
+	PREFIX+'template-literals',
+	PREFIX+'classes',
+	PREFIX+'computed-properties',
+	PREFIX+'for-of',
+	PREFIX+'spread',
+	PREFIX+'destructuring',
+	PREFIX+'modules-commonjs'
+];
+
+function getPluginEntry(name) {
+	var plugin = require('../node_modules/babel-preset-es2015/node_modules/babel-plugin-'+name);
+	for (var i=es2015Loose.plugins.length; i--; ) {
+		var p = es2015Loose.plugins[i];
+		if (p===plugin || p[0]===plugin) {
+			return p;
+		}
+	}
+	return false;
+}
+
+
+SHOULD_BE_LOOSE.forEach(function(name) {
+	test(name, function(t) {
+		t.plan(3);
+		var entry = getPluginEntry(name);
+
+		t.ok(entry, 'Entry for '+name+' should exist');
+		t.ok(Array.isArray(entry), 'Entry for '+name+' should be an Array');
+		t.deepEqual(entry[1], LOOSE, 'Entry for '+name+' should specify {loose:true}');
+	});
+});


### PR DESCRIPTION
Hiya!  I love being able to just install `es2015-loose`, but I worry about keeping this preset in sync with `babel-preset-es2015`.

This PR takes the same modifications you were manually making to the `es2015` preset, but does them in-code via [modify-babel-preset](https://github.com/developit/modify-babel-preset).  It also adds `babel-preset-es2015` as a `peerDependency` so that users are prompted to install it when they install `-loose`, but the version is (mostly) up to them.  For now I've left it as a wildcard, `modify-babel-preset` should work with any version of the 2015 preset.

In order to make this nice and safe, I've kept the existing style and added complete tests _(run via `npm test` or [travis](https://github.com/developit/modify-babel-preset/blob/master/.travis.yml))_.

I'd love any feedback you have, and hopefully you find this useful!
