### PR TITLE
Readme: Also install the peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ enable loose mode where available.
 ## Install
 
 ```sh
-$ npm install --save-dev babel-preset-es2015-loose
+$ npm install --save-dev babel-preset-es2015-loose babel-preset-es2015
 ```
 
 ## Usage


### PR DESCRIPTION
With 6.2.0 our project broke, as the peerDependency was not installed. Would be nice to at least have it in the Readme.
